### PR TITLE
Progress output

### DIFF
--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -46,7 +46,6 @@ public:
     if (file.isOpen())
     {
       resize(file.getFrames(), file.getChannels(), file.getSamplingRate());
-
       file.seek();
       file.readInterleaved(mData.data(),file.getFrames());
     }
@@ -88,11 +87,12 @@ public:
       uint16_t chans = static_cast<uint16_t>(
           std::min(asSigned(std::numeric_limits<uint16_t>::max()), numChans()));
 
-      HISSTools::OAudioFile file(mPath, fileType, depthType, chans,
+        HISSTools::OAudioFile file(mPath, fileType, depthType, chans,
                                  mSamplingRate);
 
       if (file.isOpen())
       {
+        std::cout << "Writing " << mPath << '\n';
         file.seek();
         file.writeInterleaved(mData.data(), static_cast<uint32_t>(numFrames()));
         
@@ -423,29 +423,28 @@ public:
     if(!readSuccess) return -1; 
 
     // Create client after all parameters are set
-        // Create client after all parameters are set
+
     ClientType   client(params);
     Result result;
 
     client.enqueue(params);
     result = client.process();
     
-    double progress = 0.0; // Variable to store progress
+    double progress = 0.0;
 
     while(result.ok())
     {
         ProcessState state = client.checkProgress(result);
       
         if (state == ProcessState::kDone || state == ProcessState::kDoneStillProcessing) {
-          std::cout << '\n';
+          std::cout << "100%\n";
           break;
         }
         if (state != ProcessState::kDone) {
           double newProgress = client.progress();
           if (newProgress - progress >=0.01)
           {
-            std::cout << newProgress << '\r' << std::flush;
-            
+            std::cout << std::setw(3)  << static_cast<int>(100 * newProgress) << "%\r" << std::flush;
             progress = newProgress;
           }
           using namespace std::chrono_literals;
@@ -457,11 +456,13 @@ public:
     if (!result.ok())
     {
       // Output error
+      
       std::cerr << result.message() << "\n";
     }
     else
     {
       // Write files
+      
       bool allowCSV = true;
       bool fileWriteResult = true;
       params.template forEachParamType<BufferT, WriteFiles>(allowCSV, fileWriteResult);
@@ -474,5 +475,3 @@ public:
 
 } // namespace client
 } // namespace fluid
-
-

--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -390,23 +390,32 @@ public:
     params.constrainParameterValues();
 
     // Create client after all parameters are set
-    FluidContext context;
+        // Create client after all parameters are set
     ClientType   client(params);
     Result result;
-    using namespace std::chrono_literals;
 
-    client.process();
-    ProcessState state = client.checkProgress(result);
+    client.enqueue(params);
+    result = client.process();
+    
     double progress = 0.0; // Variable to store progress
 
-    while(true) 
+    while(result.ok())
     {
+        ProcessState state = client.checkProgress(result);
+      
         if (state == ProcessState::kDone || state == ProcessState::kDoneStillProcessing) {
+          std::cout << '\n';
           break;
         }
         if (state != ProcessState::kDone) {
-          if (client.progress() - progress >=1) std::cout << client.progress() << "\n";
-          progress = client.progress();
+          double newProgress = client.progress();
+          if (newProgress - progress >=0.01)
+          {
+            std::cout << newProgress << '\r' << std::flush;
+            
+            progress = newProgress;
+          }
+          using namespace std::chrono_literals;
           std::this_thread::sleep_for(20ms); 
           continue; 
         }
@@ -430,3 +439,5 @@ public:
 
 } // namespace client
 } // namespace fluid
+
+

--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -18,10 +18,12 @@ under the European Union’s Horizon 2020 research and innovation programme
 #include <clients/common/ParameterTypes.hpp>
 #include <FluidVersion.hpp>
 #include <cctype>
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <regex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -392,18 +392,34 @@ public:
     // Create client after all parameters are set
     FluidContext context;
     ClientType   client(params);
-    auto         result = client.process(context);
+    Result result;
+    using namespace std::chrono_literals;
+
+    client.process();
+    ProcessState state = client.checkProgress(result);
+    double progress = 0.0; // Variable to store progress
+
+    while(true) 
+    {
+        if (state == ProcessState::kDone || state == ProcessState::kDoneStillProcessing) {
+          break;
+        }
+        if (state != ProcessState::kDone) {
+          if (client.progress() - progress >=1) std::cout << client.progress() << "\n";
+          progress = client.progress();
+          std::this_thread::sleep_for(20ms); 
+          continue; 
+        }
+    }
 
     if (!result.ok())
     {
       // Output error
-
       std::cerr << result.message() << "\n";
     }
     else
     {
       // Write files
-
       bool allowCSV = true;
       params.template forEachParamType<BufferT, WriteFiles>(allowCSV);
     }

--- a/src/fluid-ampgate/fluid-ampgate.cpp
+++ b/src/fluid-ampgate/fluid-ampgate.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTAmpGateClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedAmpGateClient>::run(argc, argv);
 }

--- a/src/fluid-ampslice/fluid-ampslice.cpp
+++ b/src/fluid-ampslice/fluid-ampslice.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTAmpSliceClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedAmpSliceClient>::run(argc, argv);
 }

--- a/src/fluid-hpss/fluid-hpss.cpp
+++ b/src/fluid-hpss/fluid-hpss.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTHPSSClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedHPSSClient>::run(argc, argv);
 }

--- a/src/fluid-loudness/fluid-loudness.cpp
+++ b/src/fluid-loudness/fluid-loudness.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTLoudnessClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedLoudnessClient>::run(argc, argv);
 }

--- a/src/fluid-melbands/fluid-melbands.cpp
+++ b/src/fluid-melbands/fluid-melbands.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTMelBandsClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedMelBandsClient>::run(argc, argv);
 }

--- a/src/fluid-mfcc/fluid-mfcc.cpp
+++ b/src/fluid-mfcc/fluid-mfcc.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTMFCCClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedMFCCClient>::run(argc, argv);
 }

--- a/src/fluid-nmf/fluid-nmf.cpp
+++ b/src/fluid-nmf/fluid-nmf.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NMFClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedNMFClient>::run(argc, argv);
 }

--- a/src/fluid-noveltyslice/fluid-noveltyslice.cpp
+++ b/src/fluid-noveltyslice/fluid-noveltyslice.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTNoveltySliceClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadingNoveltySliceClient>::run(argc, argv);
 }

--- a/src/fluid-onsetslice/fluid-onsetslice.cpp
+++ b/src/fluid-onsetslice/fluid-onsetslice.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTOnsetSliceClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadingOnsetSliceClient>::run(argc, argv);
 }

--- a/src/fluid-pitch/fluid-pitch.cpp
+++ b/src/fluid-pitch/fluid-pitch.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTPitchClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedPitchClient>::run(argc, argv);
 }

--- a/src/fluid-sines/fluid-sines.cpp
+++ b/src/fluid-sines/fluid-sines.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTSinesClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedSinesClient>::run(argc, argv);
 }

--- a/src/fluid-spectralshape/fluid-spectralshape.cpp
+++ b/src/fluid-spectralshape/fluid-spectralshape.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTSpectralShapeClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedSpectralShapeClient>::run(argc, argv);
 }

--- a/src/fluid-stats/fluid-stats.cpp
+++ b/src/fluid-stats/fluid-stats.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<BufStatsClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedBufStatsClient>::run(argc, argv);
 }

--- a/src/fluid-transients/fluid-transients.cpp
+++ b/src/fluid-transients/fluid-transients.cpp
@@ -15,5 +15,5 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTTransientsClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedTransientsClient>::run(argc, argv);
 }

--- a/src/fluid-transientslice/fluid-transientslice.cpp
+++ b/src/fluid-transientslice/fluid-transientslice.cpp
@@ -15,5 +15,7 @@ under the European Union’s Horizon 2020 research and innovation programme
 int main(int argc, const char* argv[])
 {
   using namespace fluid::client;
-  return CLIWrapper<NRTTransientSliceClient>::run(argc, argv);
+  // return CLIWrapper<NRTTransientSliceClient>::run(argc, argv);
+  return CLIWrapper<NRTThreadedTransientSliceClient>::run(argc, argv);
+
 }


### PR DESCRIPTION
adds 
* a fixed width progress output (no fancy terminal progress bar, but hopefully parse-able by both people and machines), 
* `Writing <X>` during the output rendering (as this can take a while as well).  

This is based on the work @jamesb93 did in his PR #2, mostly just tweaking the output formatting and merging updates back in. 

This, hopefully, makes things feel a little more responsive. Feedback sought (incl. @jamesb93 – can you try with ReaCoMa and confirm (or not) that you can work with this). 

I guess if it turns out people are doing a lot of shell scripty stuff and don't want the noise, we can add a `--quiet` switch.