### PR TITLE
Produce less surpising csv output (e.g. for AmpGate)

### DIFF
--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -60,15 +60,14 @@ public:
     if (allowCSV && (pathLength > 4) &&
         !mPath.compare(pathLength - 4, 4, ".csv"))
     {
-      FluidTensorView<const float, 2> view{mData.data(), 0, numChans(),
-                                           numFrames()};
-
+      FluidTensorView<const float, 2> view{mData.data(), 0, numFrames(),
+                                           numChans()};                         
       std::ofstream file(mPath.c_str());
 
       if (file.is_open())
       {
         file << std::setprecision(std::numeric_limits<float>::max_digits10)
-             << view;
+             << view.transpose();
         file.close();
       }
       else


### PR DESCRIPTION
Turns out I broke the multichannel CSV output in d88e471f07fd9418e7d099e7401339c1fa10ab42 when changing the layout of internal storage to speed up audio file writing. 

h/t @AlexHarker and @jamesb93  for alerting me. 

@jamesb93 will report back here with any problems this creates for ReaCoMa when he has time