### PR TITLE
nightly releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,34 @@ on:
     branches: [ dev, enhance/ci ]
 
 jobs:
+  docs:
+      runs-on: ubuntu-18.04
+
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: install ninja
+          run: sudo apt update && sudo apt install ninja-build
+          
+        - name: make build directory
+          run: mkdir -p build
+
+        - name: clone latest flucoma-core 
+          run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+        
+        - name: cmake
+          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON ..
+          working-directory: build
+          
+        - name: install
+          run: ninja MAKE_CLI_REF
+          working-directory: build
+
+        - uses: actions/upload-artifact@v2
+          with:
+            name: docs
+            path: build/cli_ref
+
   windows:
     runs-on: windows-latest
 
@@ -24,10 +52,6 @@ jobs:
     - name: build binaries
       run: cmake --build . --target install --config Release
       working-directory: build
-
-    # - name: compress release
-    #   run: tar -cvzf FluCoMa-CLI-Windows.tar.gz FluidCorpusManipulation
-    #   working-directory: release-packaging 
 
     - name: compress release
       run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-CLI-Windows-nightly.zip
@@ -59,10 +83,6 @@ jobs:
       - name: ninja install
         run: ninja install
         working-directory: build
-      
-      # - name: compress release
-      #   run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
-      #   working-directory: release-packaging
 
       - name: compress release
         run: zip -r ../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
@@ -111,6 +131,15 @@ jobs:
     needs: [windows, linux, macos]
 
     steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: docs
+          path: .
+      
+      - name: see
+        run: ls
+
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   docs:
       runs-on: macos-11
-
       steps:
         - uses: actions/checkout@v2
 
@@ -26,7 +25,14 @@ jobs:
         - name: clone latest flucoma-docs
           run: git clone --branch dev https://github.com/flucoma/flucoma-docs.git docs
         
-        - name: cmake
+        - uses: actions/cache@v2
+          id: cache
+          with:
+            path: build
+            key: ${{ runner.os }}-${{ hashFiles('build') }}
+
+        - name: generate cmake configuration
+          if: steps.cache.outputs.cache-hit != 'true' 
           run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
           working-directory: build
           
@@ -41,7 +47,6 @@ jobs:
 
   windows:
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
       
@@ -51,7 +56,14 @@ jobs:
     - name: clone latest flucoma-core 
       run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core    
     
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: build
+        key: ${{ runner.os }}-${{ hashFiles('build') }}
+
     - name: cmake
+      if: steps.cache.outputs.cache-hit != 'true' 
       run: cmake -DFLUID_PATH="../core" ..
       working-directory: build
       
@@ -66,7 +78,6 @@ jobs:
   
   macos:
     runs-on: macos-11
-
     steps:
       - uses: actions/checkout@v2
 
@@ -79,7 +90,14 @@ jobs:
       - name: Clone latest flucoma-core 
         run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
       
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: build
+          key: ${{ runner.os }}-${{ hashFiles('build') }}
+
       - name: Run cmake configuration
+        if: steps.cache.outputs.cache-hit != 'true' 
         run: cmake -GNinja -DFLUID_PATH=../core ..
         working-directory: build
         
@@ -94,7 +112,6 @@ jobs:
       
   linux:
     runs-on: ubuntu-18.04
-
     steps:
       - uses: actions/checkout@v2
 
@@ -107,7 +124,14 @@ jobs:
       - name: clone latest flucoma-core 
         run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
       
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: build
+          key: ${{ runner.os }}-${{ hashFiles('build') }}
+
       - name: cmake
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cmake -GNinja -DFLUID_PATH=../core ..
         working-directory: build
         
@@ -125,7 +149,6 @@ jobs:
     needs: [windows, linux, macos, docs]
 
     steps:
-
       - uses: actions/download-artifact@v2
         with:
           name: docs
@@ -135,10 +158,6 @@ jobs:
         with:
           name: linuxbuild
           path: linux
-
-      - name: see
-        run: ls
-        working-directory: linux
       
       - name: copy docs to linux
         run: cp -r docs linux

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly Releases
 
 on:
   push:
-    branches: [ dev, ci/** ]
+    branches: [ dev, ci/**, enhance/ci ]
 
 jobs:
   docs:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -143,7 +143,7 @@ jobs:
           prerelease: true
           body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: FluCoMa-CLI-*.zip
+          file: "FluCoMa-CLI-*.zip"
           file_glob: true
           tag: nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,7 +30,7 @@ jobs:
     #   working-directory: release-packaging 
 
     - name: compress release
-      run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-CLI-Windows.zip
+      run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-CLI-Windows-nightly.zip
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -135,7 +135,7 @@ jobs:
           release_name: FluCoMa CLI Nightly Release
           prerelease: true
           file_glob: true
-          file: FluCoMa-CLI-*.tar.gz
+          file: FluCoMa-CLI-*
           body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -61,10 +61,10 @@ jobs:
         run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
         working-directory: release-packaging
       
-        - uses: actions/upload-artifact@v2
-          with:
-            name: macbuild
-            path: release-packaging/FluCoMa-CLI-Mac.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macbuild
+          path: release-packaging/FluCoMa-CLI-Mac.tar.gz
 
   linux:
     runs-on: ubuntu-18.04

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -134,10 +134,10 @@ jobs:
         with:
           release_name: FluCoMa CLI Nightly Release
           prerelease: true
-          file_glob: true
-          file: FluCoMa-CLI-*
           body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: FluCoMa-CLI-*.tar.gz
+          file_glob: true
           tag: nightly
           overwrite: true
         

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,9 +19,12 @@ jobs:
 
         - name: clone latest flucoma-core 
           run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+
+        - name: clone latest flucoma-docs
+          run: git clone --branch dev https://github.com/flucoma/flucoma-docs.git docs
         
         - name: cmake
-          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON ..
+          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
           working-directory: build
           
         - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,20 +6,20 @@ on:
 
 jobs:
   docs:
-      runs-on: macos-11
-      steps:
-        - uses: actions/checkout@v2
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
 
-        - name: setup environment
-          uses: flucoma/actions/env@v2
-          
-        - name: build docs
-          uses: flucoma/actions/cli@v2
+      - name: setup environment
+        uses: flucoma/actions/env@v2
+        
+      - name: build docs
+        uses: flucoma/actions/clidocs@v2
 
-        - uses: actions/upload-artifact@v2
-          with:
-            name: docs
-            path: build/cli_ref
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: build/cli_ref
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -114,17 +114,17 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: FluCoMa-CLI-Linux-nightly.zip
+          path: .
 
       - uses: actions/download-artifact@v2
         with:
           name: macbuild
-          path: FluCoMa-CLI-Mac-nightly.zip
+          path: .
 
       - uses: actions/download-artifact@v2
         with:
           name: winbuild
-          path: FluCoMa-CLI-Windows-nightly.zip
+          path: .
 
       - name: ls
         run: ls
@@ -143,7 +143,7 @@ jobs:
           prerelease: true
           body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: "FluCoMa-CLI-*.zip"
+          file: FluCoMa-CLI-*.zip
           file_glob: true
           tag: nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: winbuild
-        path: release-packaging/FluCoMa-CLI-Windows-nightly.zip
+        path: FluCoMa-CLI-Windows-nightly.zip
   
   macos:
     runs-on: macos-11
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: macbuild
-          path: release-packaging/FluCoMa-CLI-Mac-nightly.zip
+          path: FluCoMa-CLI-Mac-nightly.zip
 
   linux:
     runs-on: ubuntu-18.04
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: linuxbuild
-          path: release-packaging/FluCoMa-CLI-Linux-nightly.zip
+          path: FluCoMa-CLI-Linux-nightly.zip
   
   
   release:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -104,7 +104,6 @@ jobs:
     needs: [windows, linux, macos]
 
     steps:
-
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
@@ -119,6 +118,9 @@ jobs:
         with:
           name: winbuild
           path: FluCoMa-CLI-Windows.tar.gz
+
+      - name: ls
+        run: ls
   
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
@@ -130,7 +132,7 @@ jobs:
       - name: package and upload
         uses: svenstaro/upload-release-action@v2
         with:
-          release_name: FluCoMa Max Nightly Build
+          release_name: FluCoMa CLI Nightly Release
           prerelease: true
           file_glob: true
           file: FluCoMa-CLI-*.tar.gz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,13 +6,16 @@ on:
 
 jobs:
   docs:
-      runs-on: ubuntu-18.04
+      runs-on: macos-11
 
       steps:
         - uses: actions/checkout@v2
 
-        - name: install ninja
-          run: sudo apt update && sudo apt install ninja-build
+        # - name: install ninja
+        #   run: sudo apt update && sudo apt install ninja-build
+
+        - name: Install ninja
+          run: brew install ninja
           
         - name: make build directory
           run: mkdir -p build
@@ -127,7 +130,6 @@ jobs:
         with:
           name: linuxbuild
           path: FluCoMa-CLI-Linux-nightly.zip
-  
   
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,14 +25,17 @@ jobs:
       run: cmake --build . --target install --config Release
       working-directory: build
 
+    # - name: compress release
+    #   run: tar -cvzf FluCoMa-CLI-Windows.tar.gz FluidCorpusManipulation
+    #   working-directory: release-packaging 
+
     - name: compress release
-      run: tar -cvzf FluCoMa-CLI-Windows.tar.gz FluidCorpusManipulation
-      working-directory: release-packaging 
+      run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-CLI-Windows.zip
 
     - uses: actions/upload-artifact@v2
       with:
         name: winbuild
-        path: release-packaging/FluCoMa-CLI-Windows.tar.gz
+        path: release-packaging/FluCoMa-CLI-Windows-nightly.zip
   
   macos:
     runs-on: macos-11
@@ -57,14 +60,18 @@ jobs:
         run: ninja install
         working-directory: build
       
+      # - name: compress release
+      #   run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
+      #   working-directory: release-packaging
+
       - name: compress release
-        run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
+        run: zip -r ../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
         working-directory: release-packaging
       
       - uses: actions/upload-artifact@v2
         with:
           name: macbuild
-          path: release-packaging/FluCoMa-CLI-Mac.tar.gz
+          path: release-packaging/FluCoMa-CLI-Mac-nightly.zip
 
   linux:
     runs-on: ubuntu-18.04
@@ -90,13 +97,13 @@ jobs:
         working-directory: build
 
       - name: compress release
-        run: tar -cvzf FluCoMa-CLI-Linux.tar.gz FluidCorpusManipulation
-        working-directory: release-packaging 
+        run: zip -r ../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
+        working-directory: release-packaging
 
       - uses: actions/upload-artifact@v2
         with:
           name: linuxbuild
-          path: release-packaging/FluCoMa-CLI-Linux.tar.gz
+          path: release-packaging/FluCoMa-CLI-Linux-nightly.zip
   
   
   release:
@@ -107,17 +114,17 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: FluCoMa-CLI-Linux.tar.gz
+          path: FluCoMa-CLI-Linux-nightly.zip
 
       - uses: actions/download-artifact@v2
         with:
           name: macbuild
-          path: FluCoMa-CLI-Mac.tar.gz
+          path: FluCoMa-CLI-Mac-nightly.zip
 
       - uses: actions/download-artifact@v2
         with:
           name: winbuild
-          path: FluCoMa-CLI-Windows.tar.gz
+          path: FluCoMa-CLI-Windows-nightly.zip
 
       - name: ls
         run: ls
@@ -136,7 +143,7 @@ jobs:
           prerelease: true
           body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: FluCoMa-CLI-*.tar.gz
+          file: FluCoMa-CLI-*.zip
           file_glob: true
           tag: nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,10 +11,10 @@ jobs:
       steps:
         - uses: actions/checkout@v2
 
-        # - name: install ninja
-        #   run: sudo apt update && sudo apt install ninja-build
+        - name: install python dependencies
+          run: pip3 install pyyaml docutils jinja2
 
-        - name: Install ninja
+        - name: install ninja
           run: brew install ninja
           
         - name: make build directory
@@ -133,7 +133,7 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
-    needs: [windows, linux, macos]
+    needs: [windows, linux, macos, docs]
 
     steps:
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -135,6 +135,10 @@ jobs:
         with:
           name: linuxbuild
           path: linux
+
+      - name: see
+        run: ls
+        working-directory: linux
       
       - name: copy docs to linux
         run: cp -r docs linux/release-packaging/FluidCorpusManipulation

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,141 @@
+name: Nightly Releases
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: make build directory
+      run: mkdir -p build
+
+    - name: clone latest flucoma-core 
+      run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core    
+    
+    - name: cmake
+      run: cmake -DFLUID_PATH="../core" ..
+      working-directory: build
+      
+    - name: build binaries
+      run: cmake --build . --target install --config Release
+      working-directory: build
+
+    - name: compress release
+      run: tar -cvzf FluCoMa-CLI-Windows.tar.gz FluidCorpusManipulation
+      working-directory: release-packaging 
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: winbuild
+        path: release-packaging/FluCoMa-CLI-Windows.tar.gz
+  
+  macos:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ninja
+        run: brew install ninja
+        
+      - name: create build directory
+        run: mkdir -p build
+
+      - name: Clone latest flucoma-core 
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+      
+      - name: Run cmake configuration
+        run: cmake -GNinja -DFLUID_PATH=../core ..
+        working-directory: build
+        
+      - name: ninja install
+        run: ninja install
+        working-directory: build
+      
+    - name: compress release
+      run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
+      working-directory: release-packaging
+    
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macbuild
+          path: release-packaging/FluCoMa-CLI-Mac.tar.gz
+
+  linux:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install ninja
+        run: sudo apt update && sudo apt install ninja-build
+        
+      - name: make build directory
+        run: mkdir -p build
+
+      - name: clone latest flucoma-core 
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+      
+      - name: cmake
+        run: cmake -GNinja -DFLUID_PATH=../core ..
+        working-directory: build
+        
+      - name: install
+        run: ninja install
+        working-directory: build
+
+      - name: compress release
+        run: tar -cvzf FluCoMa-CLI-Linux.tar.gz FluidCorpusManipulation
+        working-directory: release-packaging 
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linuxbuild
+          path: release-packaging/FluCoMa-CLI-Linux.tar.gz
+  
+  
+  release:
+    runs-on: ubuntu-latest
+    needs: [windows, linux, macos]
+
+    steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: linuxbuild
+          path: FluCoMa-CLI-Linux.tar.gz
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: macbuild
+          path: FluCoMa-CLI-Mac.tar.gz
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: winbuild
+          path: FluCoMa-CLI-Windows.tar.gz
+  
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true # default: false
+          tag_name: nightly # tag name to delete
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: package and upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: FluCoMa Max Nightly Build
+          prerelease: true
+          file_glob: true
+          file: FluCoMa-CLI-*.tar.gz
+          body: "This is a nightly build of the FluCoMa CLI tools. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: nightly
+          overwrite: true
+        

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -141,11 +141,11 @@ jobs:
         working-directory: linux
       
       - name: copy docs to linux
-        run: cp -r docs linux/release-packaging/FluidCorpusManipulation
+        run: cp -r docs linux
 
       - name: compress linux
-        run: zip -r ../../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
-        working-directory: linux/release-packaging
+        run: zip -r ../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
+        working-directory: linux
 
       - uses: actions/download-artifact@v2
         with:
@@ -153,11 +153,11 @@ jobs:
           path: mac
 
       - name: copy docs to mac
-        run: cp -r docs mac/release-packaging/FluidCorpusManipulation
+        run: cp -r docs mac
 
       - name: compress mac
-        run: zip -r ../../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
-        working-directory: mac/release-packaging
+        run: zip -r ../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
+        working-directory: mac
 
       - uses: actions/download-artifact@v2
         with:
@@ -165,11 +165,11 @@ jobs:
           path: win
 
       - name: copy docs to windows
-        run: cp -r docs win/release-packaging/FluidCorpusManipulation
+        run: cp -r docs win
 
       - name: compress windows
-        run: zip -r ../../FluCoMa-CLI-Windows-nightly.zip FluidCorpusManipulation
-        working-directory: win/release-packaging
+        run: zip -r ../FluCoMa-CLI-Windows-nightly.zip FluidCorpusManipulation
+        working-directory: win
   
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -144,7 +144,7 @@ jobs:
         run: cp -r docs linux
 
       - name: compress linux
-        run: zip -r ../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
+        run: zip -r ../FluCoMa-CLI-Linux-nightly.zip .
         working-directory: linux
 
       - uses: actions/download-artifact@v2
@@ -156,7 +156,7 @@ jobs:
         run: cp -r docs mac
 
       - name: compress mac
-        run: zip -r ../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
+        run: zip -r ../FluCoMa-CLI-Mac-nightly.zip .
         working-directory: mac
 
       - uses: actions/download-artifact@v2
@@ -168,7 +168,7 @@ jobs:
         run: cp -r docs win
 
       - name: compress windows
-        run: zip -r ../FluCoMa-CLI-Windows-nightly.zip FluidCorpusManipulation
+        run: zip -r ../FluCoMa-CLI-Windows-nightly.zip .
         working-directory: win
   
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly Releases
 
 on:
   push:
-    branches: [ dev, enhance/ci ]
+    branches: [ dev, ci/** ]
 
 jobs:
   docs:
@@ -10,35 +10,11 @@ jobs:
       steps:
         - uses: actions/checkout@v2
 
-        - name: install python dependencies
-          run: pip3 install pyyaml docutils jinja2
-
-        - name: install ninja
-          run: brew install ninja
+        - name: setup environment
+          uses: flucoma/actions/env@v2
           
-        - name: make build directory
-          run: mkdir -p build
-
-        - name: clone latest flucoma-core 
-          run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
-
-        - name: clone latest flucoma-docs
-          run: git clone --branch dev https://github.com/flucoma/flucoma-docs.git docs
-        
-        - uses: actions/cache@v2
-          id: cache
-          with:
-            path: build
-            key: ${{ runner.os }}-${{ hashFiles('build') }}
-
-        - name: generate cmake configuration
-          if: steps.cache.outputs.cache-hit != 'true' 
-          run: cmake -GNinja -DFLUID_PATH=../core -DDOCS=ON -DFLUID_DOCS_PATH=../docs ..
-          working-directory: build
-          
-        - name: install
-          run: ninja MAKE_CLI_REF
-          working-directory: build
+        - name: build docs
+          uses: flucoma/actions/cli@v2
 
         - uses: actions/upload-artifact@v2
           with:
@@ -50,26 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - name: make build directory
-      run: mkdir -p build
-
-    - name: clone latest flucoma-core 
-      run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core    
-    
-    - uses: actions/cache@v2
-      id: cache
-      with:
-        path: build
-        key: ${{ runner.os }}-${{ hashFiles('build') }}
-
-    - name: cmake
-      if: steps.cache.outputs.cache-hit != 'true' 
-      run: cmake -DFLUID_PATH="../core" ..
-      working-directory: build
+    - name: setup environment
+      uses: flucoma/actions/env@v2
       
-    - name: build binaries
-      run: cmake --build . --target install --config Release
-      working-directory: build
+    - name: build docs
+      uses: flucoma/actions/cli@v2
 
     - uses: actions/upload-artifact@v2
       with:
@@ -81,29 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install ninja
-        run: brew install ninja
-        
-      - name: create build directory
-        run: mkdir -p build
-
-      - name: Clone latest flucoma-core 
-        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
+      - name: setup environment
+        uses: flucoma/actions/env@v2
       
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: build
-          key: ${{ runner.os }}-${{ hashFiles('build') }}
-
-      - name: Run cmake configuration
-        if: steps.cache.outputs.cache-hit != 'true' 
-        run: cmake -GNinja -DFLUID_PATH=../core ..
-        working-directory: build
-        
-      - name: ninja install
-        run: ninja install
-        working-directory: build
+      - name: build docs
+        uses: flucoma/actions/cli@v2
 
       - uses: actions/upload-artifact@v2
         with:
@@ -115,29 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install ninja
-        run: sudo apt update && sudo apt install ninja-build
+      - name: setup environment
+        uses: flucoma/actions/env@v2
         
-      - name: make build directory
-        run: mkdir -p build
-
-      - name: clone latest flucoma-core 
-        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core
-      
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: build
-          key: ${{ runner.os }}-${{ hashFiles('build') }}
-
-      - name: cmake
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cmake -GNinja -DFLUID_PATH=../core ..
-        working-directory: build
-        
-      - name: install
-        run: ninja install
-        working-directory: build
+      - name: build docs
+        uses: flucoma/actions/cli@v2
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -59,13 +59,10 @@ jobs:
       run: cmake --build . --target install --config Release
       working-directory: build
 
-    - name: compress release
-      run: Compress-Archive release-packaging/FluidCorpusManipulation FluCoMa-CLI-Windows-nightly.zip
-
     - uses: actions/upload-artifact@v2
       with:
         name: winbuild
-        path: FluCoMa-CLI-Windows-nightly.zip
+        path: release-packaging/FluidCorpusManipulation
   
   macos:
     runs-on: macos-11
@@ -90,15 +87,11 @@ jobs:
         run: ninja install
         working-directory: build
 
-      - name: compress release
-        run: zip -r ../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
-        working-directory: release-packaging
-      
       - uses: actions/upload-artifact@v2
         with:
           name: macbuild
-          path: FluCoMa-CLI-Mac-nightly.zip
-
+          path: release-packaging/FluidCorpusManipulation
+      
   linux:
     runs-on: ubuntu-18.04
 
@@ -122,14 +115,10 @@ jobs:
         run: ninja install
         working-directory: build
 
-      - name: compress release
-        run: zip -r ../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
-        working-directory: release-packaging
-
       - uses: actions/upload-artifact@v2
         with:
           name: linuxbuild
-          path: FluCoMa-CLI-Linux-nightly.zip
+          path: release-packaging/FluidCorpusManipulation
   
   release:
     runs-on: ubuntu-latest
@@ -140,28 +129,43 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: docs
-          path: .
-      
-      - name: see
-        run: ls
+          path: docs
 
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: .
+          path: linux
+      
+      - name: copy docs to linux
+        run: cp -r docs linux/release-packaging/FluidCorpusManipulation
+
+      - name: compress linux
+        run: zip -r ../../FluCoMa-CLI-Linux-nightly.zip FluidCorpusManipulation
+        working-directory: linux/release-packaging
 
       - uses: actions/download-artifact@v2
         with:
           name: macbuild
-          path: .
+          path: mac
+
+      - name: copy docs to mac
+        run: cp -r docs mac/release-packaging/FluidCorpusManipulation
+
+      - name: compress mac
+        run: zip -r ../../FluCoMa-CLI-Mac-nightly.zip FluidCorpusManipulation
+        working-directory: mac/release-packaging
 
       - uses: actions/download-artifact@v2
         with:
           name: winbuild
-          path: .
+          path: win
 
-      - name: ls
-        run: ls
+      - name: copy docs to windows
+        run: cp -r docs win/release-packaging/FluidCorpusManipulation
+
+      - name: compress windows
+        run: zip -r ../../FluCoMa-CLI-Windows-nightly.zip FluidCorpusManipulation
+        working-directory: win/release-packaging
   
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,14 +57,14 @@ jobs:
         run: ninja install
         working-directory: build
       
-    - name: compress release
-      run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
-      working-directory: release-packaging
-    
-      - uses: actions/upload-artifact@v2
-        with:
-          name: macbuild
-          path: release-packaging/FluCoMa-CLI-Mac.tar.gz
+      - name: compress release
+        run: tar -cvzf FluCoMa-CLI-Mac.tar.gz FluidCorpusManipulation
+        working-directory: release-packaging
+      
+        - uses: actions/upload-artifact@v2
+          with:
+            name: macbuild
+            path: release-packaging/FluCoMa-CLI-Mac.tar.gz
 
   linux:
     runs-on: ubuntu-18.04

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly Releases
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ dev, enhance/ci ]
 
 jobs:
   windows:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,12 +45,14 @@ FetchContent_Declare(
   flucoma-core
   GIT_REPOSITORY https://github.com/flucoma/flucoma-core.git
   GIT_PROGRESS TRUE
+  GIT_TAG origin/main
 )
 
 FetchContent_Declare(
   flucoma-docs
   GIT_REPOSITORY https://github.com/flucoma/flucoma-docs.git
   GIT_PROGRESS TRUE
+  GIT_TAG origin/main
 )
 
 if(FLUID_PATH)


### PR DESCRIPTION
This adds continuous integration to create nightly builds on any commits made to the `dev` branch of this repo.

Can be seen in action [here](https://github.com/jamesb93/flucoma-cli/releases).

