### PR TITLE
[feature] stdout writing

### DIFF
--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -77,6 +77,11 @@ public:
         std::cerr << "Could not open file " << mPath << " for writing\n";
       }
     }
+    else if (allowCSV && !mPath.compare(0, 6, "stdout"))
+    {
+      FluidTensorView<const float, 2> view{ mData.data(), 0, numFrames(), numChans() };                         
+      std::cout << view.transpose();
+    }
     else
     {
       // TODO: file extensions/paths


### PR DESCRIPTION
Adds support for setting the output to stdout.

Interface isn't great and is not very "UNIX"y, however, it works.

For example, you can specify output like this:

```sh
fluid-noveltyfeature -source infile.wav -features stdout
```

This will write the values out with commas inbetween them.

---

# Why?

The major benefit of this format is that you don't need to manage, cleanup and parse an intermediary file if you have the CLI tools embedded elsewhere. My selfish reason is to remove those needs from ReaCoMa. It would also facilitate viewing results more easily in the terminal if you want to prototype there fast.
