### PR TITLE
Add custom allocator to PD wrapper

### DIFF
--- a/include/FluidCLIWrapper.hpp
+++ b/include/FluidCLIWrapper.hpp
@@ -16,6 +16,7 @@ under the European Union’s Horizon 2020 research and innovation programme
 #include <clients/common/OfflineClient.hpp>
 #include <clients/common/ParameterSet.hpp>
 #include <clients/common/ParameterTypes.hpp>
+#include <data/FluidMemory.hpp>
 #include <FluidVersion.hpp>
 #include <cctype>
 #include <chrono>
@@ -402,7 +403,7 @@ public:
 
   static int run(index argc, const char* argv[])
   {
-    ParamSetType params(descriptors());
+    ParamSetType params(descriptors(), FluidDefaultAllocator());
     FlagsType    flags;
     flags.fill(false);
 
@@ -460,8 +461,8 @@ public:
 
     // Create client after all parameters are set
 
-    ClientType   client(params);
-    Result result;
+    ClientType client(params, FluidContext());
+    Result     result;
 
     client.enqueue(params);
     result = client.process();


### PR DESCRIPTION
To go with https://github.com/flucoma/flucoma-core/pull/190 

Small changes to wrapper to deal with adding allocator awareness for RT platforms. Note that if / when the data clients get added to the CLI, some more work will be called for (but that was the case anyway).