### PR TITLE
EOL `.gitattributes` normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+*.yml text
+*.gitignore text
+*.maxpat text
+*.hpp text
+*.cmake text
+*.md text
+*.txt text
+*.yaml text
+
+*.png binary


### PR DESCRIPTION
EOL standardisation with .gitattributes to fix issues with versions of Git before 2.10 allowed automatic EOL conversion.